### PR TITLE
ulbview adjust min-height of iframe

### DIFF
--- a/ulb.php
+++ b/ulb.php
@@ -6,7 +6,7 @@
 	<div class="container">
 		<div class="row">
 				
-		<iframe src="http://www.ulb.uni-muenster.de/ULB/katalog" width="100%" height="100%" style="min-height: 500px" frameborder="no">
+		<iframe src="http://www.ulb.uni-muenster.de/ULB/katalog" width="100%" height="100%" style="min-height: 900px" frameborder="no">
             <p>Ihr Browser untersützt offenbar keine iFrames. <a href="http://www.ulb.uni-muenster.de/ULB/katalog">Direkt zum ULB Katalog</a>.</p>
         </iframe> 	
 


### PR DESCRIPTION
fix ugly scroll bars on desktop & reach bottom on android
desktop site is: 675px
mobile site is 897px
